### PR TITLE
Sets a standard for the Python files 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*.py]
+indent_style = tab
+trim_trailing_whitespace = true
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true


### PR DESCRIPTION
(so we don't keep changing tabs to spaces, etc); most editors have a plug-in for editorconfig (which reads this file in and applies before save)

For more info, see: http://editorconfig.org/#download