### PR TITLE
translation example

### DIFF
--- a/translate.py
+++ b/translate.py
@@ -1,0 +1,36 @@
+# 1. `pip install microsofttranslator` (see https://github.com/openlabs/Microsoft-Translator-Python-API for more info)
+# 2. create account per https://www.microsoft.com/en-us/translator/getstarted.aspx
+# 3. set environment variables CLIENT_ID / CLIENT_SECRET with details from Microsoft account. ex: export from ~/.bashrc
+# 4. call this script with string to translate. ex: `python translation.py Su capital es la Ciudad de México`
+
+import os
+import sys
+
+try:
+  client_id = os.environ['CLIENT_ID']
+except Exception as e:
+  print "ERROR: no environment variable set for {0}".format(str(e))
+  client_id = ''
+
+try:
+  client_secret = os.environ['CLIENT_SECRET']
+except Exception as e:
+  print "ERROR: no environment variable set for {0}".format(str(e))
+  client_secret = ''
+
+if len(sys.argv) < 2:
+  sys.exit()
+
+string_to_translate = ' '.join(sys.argv[1:])
+
+try:
+  from microsofttranslator import Translator
+  translator = Translator(client_id, client_secret)
+  response = translator.translate(string_to_translate, 'en')
+  print "RESPONSE: {0}".format(str(response))
+
+  # more details available at: https://docs.microsofttranslator.com/text-translate.html
+
+except Exception as e:
+  print "ERROR: {0}".format(str(e))
+  sys.exit()


### PR DESCRIPTION
File which can be used to translate text using Microsoft's [Translator API (v2)](https://docs.microsofttranslator.com/text-translate.html)

- run `pip install microsofttranslator`
- [create an account (free)](https://www.microsoft.com/en-us/translator/getstarted.aspx)
- set environment variables CLIENT_ID / CLIENT_SECRET with details from Microsoft account. For example, you can edit your ~/.bashrc and `source ~/.bashrc` after edit:
```bash
export CLIENT_ID=abc
export CLIENT_SECRET=def
```
- call script:
`python translation.py Su capital es la Ciudad de México`